### PR TITLE
[datadog] bug: no need to append API key to URI in v2 endpoints

### DIFF
--- a/plugins/out_datadog/datadog_conf.c
+++ b/plugins/out_datadog/datadog_conf.c
@@ -122,8 +122,6 @@ struct flb_out_datadog *flb_datadog_conf_create(struct flb_output_instance *ins,
         return NULL;
     }
 
-    /* Add the api_key to the URI */
-    ctx->uri = flb_sds_cat(ctx->uri, ctx->api_key, flb_sds_len(ctx->api_key));
     flb_plg_debug(ctx->ins, "uri: %s", ctx->uri);
 
     /* Get network configuration */


### PR DESCRIPTION
<!-- Provide summary of changes -->
We no longer need the API key in the URI after the V2 change. 

This slipped under the radar as I tested with an image that contained these changes but forgot committing them. This is not upstream yet, so no harm done.  

sample config to test:
```
[INPUT]
  Name   kmsg
  Tag    kernel 

[INPUT]
  Name        tail
  Path        /var/log/syslog

[OUTPUT]
  Name              datadog
  Match             *
  Host              http-intake.logs.datadoghq.com
  TLS               on
  compress          gzip
  apikey            <API_KEY>
  dd_service        logger
  dd_source         fluent-bit
  dd_message_key    log
  dd_tags           env:dev,owner:foo

```


[test.log](https://github.com/DataDog/fluent-bit/files/8141774/test.log) summary output:
```
[1mFluent Bit v1.9.0[0m
* [1m[93mCopyright (C) 2019-2021 The Fluent Bit Authors[0m
* [1m[93mCopyright (C) 2015-2018 Treasure Data[0m
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/02/25 08:49:59] [ info] Configuration:
[2022/02/25 08:49:59] [ info]  flush time     | 1.000000 seconds
[2022/02/25 08:49:59] [ info]  grace          | 5 seconds
[2022/02/25 08:49:59] [ info]  daemon         | 0
[2022/02/25 08:49:59] [ info] ___________
[2022/02/25 08:49:59] [ info]  inputs:
[2022/02/25 08:49:59] [ info]      dummy
[2022/02/25 08:49:59] [ info]      docker_events
[2022/02/25 08:49:59] [ info]      kmsg
[2022/02/25 08:49:59] [ info]      tail
[2022/02/25 08:49:59] [ info] ___________
[2022/02/25 08:49:59] [ info]  filters:
[2022/02/25 08:49:59] [ info] ___________
[2022/02/25 08:49:59] [ info]  outputs:
[2022/02/25 08:49:59] [ info]      stdout.0
[2022/02/25 08:49:59] [ info]      datadog.1
[2022/02/25 08:49:59] [ info] ___________
[2022/02/25 08:49:59] [ info]  collectors:
[2022/02/25 08:49:59] [ info] [engine] started (pid=658803)
[2022/02/25 08:49:59] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2022/02/25 08:49:59] [debug] [storage] [cio stream] new stream registered: dummy.0
[2022/02/25 08:49:59] [debug] [storage] [cio stream] new stream registered: docker_events.1
[2022/02/25 08:49:59] [debug] [storage] [cio stream] new stream registered: kmsg.2
[2022/02/25 08:49:59] [debug] [storage] [cio stream] new stream registered: tail.3
[2022/02/25 08:49:59] [ info] [storage] version=1.1.5, initializing...
[2022/02/25 08:49:59] [ info] [storage] in-memory
[2022/02/25 08:49:59] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/02/25 08:49:59] [ info] [cmetrics] version=0.2.2
[2022/02/25 08:49:59] [trace] [input:docker_events:docker_events.1 at plugins/in_docker_events/docker_events.c:65] writing to socket GET /events HTTP/1.0


[2022/02/25 08:49:59] [debug] [input:docker_events:docker_events.1] read 183 bytes from socket
[2022/02/25 08:49:59] [ info] [input:docker_events:docker_events.1] listening for events on /var/run/docker.sock
[2022/02/25 08:49:59] [debug] [input:tail:tail.3] flb_tail_fs_inotify_init() initializing inotify tail input
[2022/02/25 08:49:59] [debug] [input:tail:tail.3] inotify watch fd=25
[2022/02/25 08:49:59] [debug] [input:tail:tail.3] scanning path /var/log/syslog
[2022/02/25 08:49:59] [debug] [input:tail:tail.3] inode=48 with offset=8342957 appended as /var/log/syslog
[2022/02/25 08:49:59] [debug] [input:tail:tail.3] scan_glob add(): /var/log/syslog, inode 48
[2022/02/25 08:49:59] [debug] [input:tail:tail.3] 1 new files found on path '/var/log/syslog'
[2022/02/25 08:49:59] [debug] [stdout:stdout.0] created event channels: read=27 write=28
[2022/02/25 08:49:59] [debug] [datadog:datadog.1] created event channels: read=29 write=30
[2022/02/25 08:50:00] [debug] [output:datadog:datadog.1] scheme: https://
[2022/02/25 08:50:00] [debug] [output:datadog:datadog.1] uri: /api/v2/logs
[2022/02/25 08:50:00] [debug] [output:datadog:datadog.1] host: http-intake.logs.datadoghq.com
[2022/02/25 08:50:00] [debug] [output:datadog:datadog.1] port: 443
[2022/02/25 08:50:00] [debug] [output:datadog:datadog.1] json_date_key: timestamp
[2022/02/25 08:50:00] [debug] [output:datadog:datadog.1] compress_gzip: 1
[2022/02/25 08:50:00] [ warn] [router] NO match for stdout.0 output instance
[2022/02/25 08:50:00] [debug] [router] match rule dummy.0:datadog.1
[2022/02/25 08:50:00] [ warn] [router] NO match for stdout.0 output instance
[2022/02/25 08:50:00] [debug] [router] match rule docker_events.1:datadog.1
[2022/02/25 08:50:00] [ warn] [router] NO match for stdout.0 output instance
[2022/02/25 08:50:00] [debug] [router] match rule kmsg.2:datadog.1
[2022/02/25 08:50:00] [ warn] [router] NO match for stdout.0 output instance
[2022/02/25 08:50:00] [debug] [router] match rule tail.3:datadog.1
[2022/02/25 08:50:00] [ info] [sp] stream processor started
[2022/02/25 08:50:00] [debug] [input chunk] update output instances with new chunk size diff=237
[2022/02/25 08:50:00] [debug] [input:kmsg:kmsg.2] pri=5 seq=0 sec=0 usec=0 msg_length=188
[2022/02/25 08:50:00] [debug] [input:tail:tail.3] inode=48 file=/var/log/syslog promote to TAIL_EVENT
[2022/02/25 08:50:00] [ info] [input:tail:tail.3] inotify_fs_add(): inode=48 watch_fd=1 name=/var/log/syslog
...
[2022/02/25 08:50:01] [debug] [input chunk] update output instances with new chunk size diff=31
[2022/02/25 08:50:01] [debug] [net] socket #38 could not connect to 2600:1f18:24e6:b902:321b:319e:f54e:39e2:443
[2022/02/25 08:50:01] [debug] [net] socket #38 could not connect to 2600:1f18:24e6:b900:257d:732:43a5:a78c:443
[2022/02/25 08:50:01] [debug] [net] socket #38 could not connect to 2600:1f18:24e6:b900:7508:8443:852c:cd96:443
[2022/02/25 08:50:01] [debug] [net] socket #38 could not connect to 2600:1f18:24e6:b901:ee73:8f7d:8c38:8119:443
[2022/02/25 08:50:01] [debug] [net] socket #38 could not connect to 2600:1f18:24e6:b902:8ad0:6c63:d9d9:ffc2:443
[2022/02/25 08:50:01] [debug] [net] socket #38 could not connect to 2600:1f18:24e6:b902:5fd6:192c:3267:c61:443
[2022/02/25 08:50:01] [debug] [net] socket #38 could not connect to 2600:1f18:24e6:b901:b41a:821a:c7fd:b5aa:443
[2022/02/25 08:50:01] [debug] [net] socket #38 could not connect to 2600:1f18:24e6:b900:438c:625b:72d6:a69e:443
[2022/02/25 08:50:01] [debug] [input:tail:tail.3] inode=48 events: IN_MODIFY 
[2022/02/25 08:50:01] [debug] [input chunk] update output instances with new chunk size diff=356
[2022/02/25 08:50:01] [debug] [input:tail:tail.3] inode=48 events: IN_MODIFY 
[2022/02/25 08:50:01] [debug] [input chunk] update output instances with new chunk size diff=356
[2022/02/25 08:50:01] [debug] [input:tail:tail.3] inode=48 events: IN_MODIFY 
[2022/02/25 08:50:01] [debug] [input chunk] update output instances with new chunk size diff=441
[2022/02/25 08:50:01] [debug] [input:tail:tail.3] inode=48 events: IN_MODIFY 
[2022/02/25 08:50:01] [debug] [input chunk] update output instances with new chunk size diff=220
[2022/02/25 08:50:01] [debug] [input:tail:tail.3] inode=48 events: IN_MODIFY 
[2022/02/25 08:50:01] [debug] [input chunk] update output instances with new chunk size diff=110
[2022/02/25 08:50:01] [debug] [http_client] not using http_proxy for header
[2022/02/25 08:50:01] [ info] [output:datadog:datadog.1] https://http-intake.logs.datadoghq.com, port=443, HTTP status=202 payload={}
[2022/02/25 08:50:01] [debug] [upstream] KA connection #38 to http-intake.logs.datadoghq.com:443 is now available
[2022/02/25 08:50:01] [debug] [out flush] cb_destroy coro_id=0
[2022/02/25 08:50:01] [debug] [task] destroy task=0x7fed9001db70 (task_id=0)
[2022/02/25 08:50:02] [debug] [task] created task=0x7fed9001db70 id=0 OK
[2022/02/25 08:50:02] [debug] [upstream] KA connection #38 to http-intake.logs.datadoghq.com:443 has been assigned (recycled)
[2022/02/25 08:50:02] [debug] [http_client] not using http_proxy for header
[2022/02/25 08:50:02] [debug] [task] created task=0x7fed901668b0 id=1 OK
[2022/02/25 08:50:02] [debug] [input chunk] update output instances with new chunk size diff=31
[2022/02/25 08:50:02] [ info] [output:datadog:datadog.1] https://http-intake.logs.datadoghq.com, port=443, HTTP status=202 payload={}
[2022/02/25 08:50:03] [debug] [upstream] KA connection #38 to http-intake.logs.datadoghq.com:443 is now available
[2022/02/25 08:50:03] [debug] [out flush] cb_destroy coro_id=4
[2022/02/25 08:50:03] [debug] [out flush] cb_destroy coro_id=3
[2022/02/25 08:50:03] [debug] [task] destroy task=0x7fed90183af0 (task_id=1)
[2022/02/25 08:50:03] [debug] [task] destroy task=0x7fed901668b0 (task_id=0)
[2022/02/25 08:50:04] [debug] [task] created task=0x7fed901668b0 id=0 OK
[2022/02/25 08:50:04] [debug] [upstream] KA connection #39 to http-intake.logs.datadoghq.com:443 has been assigned (recycled)
[2022/02/25 08:50:04] [debug] [http_client] not using http_proxy for header
[2022/02/25 08:50:04] [debug] [input chunk] update output instances with new chunk size diff=31
[2022/02/25 08:50:04] [ info] [output:datadog:datadog.1] https://http-intake.logs.datadoghq.com, port=443, HTTP status=202 payload={}
...
```

[valgrind.log](https://github.com/DataDog/fluent-bit/files/8141763/valgrind.log) summary:
```
==662507== Memcheck, a memory error detector
==662507== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==662507== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==662507== Command: ./bin/fluent-bit -c test.config -o stdout -f1 -vv
==662507== 
[1mFluent Bit v1.9.0[0m

* [1m[93mCopyright (C) 2019-2021 The Fluent Bit Authors[0m
* [1m[93mCopyright (C) 2015-2018 Treasure Data[0m
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/02/25 09:01:54] [ info] Configuration:
[2022/02/25 09:01:54] [ info]  flush time     | 1.000000 seconds
[2022/02/25 09:01:54] [ info]  grace          | 5 seconds
[2022/02/25 09:01:54] [ info]  daemon         | 0
[2022/02/25 09:01:54] [ info] ___________
[2022/02/25 09:01:54] [ info]  inputs:
[2022/02/25 09:01:54] [ info]      dummy
[2022/02/25 09:01:54] [ info]      docker_events
[2022/02/25 09:01:54] [ info]      kmsg
[2022/02/25 09:01:54] [ info]      tail
[2022/02/25 09:01:54] [ info] ___________
[2022/02/25 09:01:54] [ info]  filters:
[2022/02/25 09:01:54] [ info] ___________
[2022/02/25 09:01:54] [ info]  outputs:
[2022/02/25 09:01:54] [ info]      stdout.0
[2022/02/25 09:01:54] [ info]      datadog.1
[2022/02/25 09:01:54] [ info] ___________
[2022/02/25 09:01:54] [ info]  collectors:
[2022/02/25 09:01:54] [ info] [engine] started (pid=662507)
[2022/02/25 09:01:54] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2022/02/25 09:01:54] [debug] [storage] [cio stream] new stream registered: dummy.0
[2022/02/25 09:01:54] [debug] [storage] [cio stream] new stream registered: docker_events.1
[2022/02/25 09:01:54] [debug] [storage] [cio stream] new stream registered: kmsg.2
[2022/02/25 09:01:54] [debug] [storage] [cio stream] new stream registered: tail.3
[2022/02/25 09:01:54] [ info] [storage] version=1.1.5, initializing...
==662507== 
==662507== HEAP SUMMARY:
==662507==     in use at exit: 0 bytes in 0 blocks
==662507==   total heap usage: 56,920 allocs, 56,920 frees, 81,089,475 bytes allocated
==662507== 
==662507== All heap blocks were freed -- no leaks are possible
==662507== 
==662507== For lists of detected and suppressed errors, rerun with: -s
==662507== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
